### PR TITLE
fix typo in reference urls

### DIFF
--- a/ruby_client.rb
+++ b/ruby_client.rb
@@ -3,8 +3,8 @@
 require 'oauth'
 require 'json'
 
-API_KEY = ''#API_KEY is the App Id of your app created in develoepr.deere.com
-API_SECRET = ''#API_SECRET is the shared secret of your app created in develoepr.deere.com
+API_KEY = ''#API_KEY is the App Id of your app created in developer.deere.com
+API_SECRET = ''#API_SECRET is the shared secret of your app created in developer.deere.com
 
 
 def getBasicCatalog(token=nil)


### PR DESCRIPTION
The URL for the developer portal is mistyped twice. This is corrected, to help developers find the right location.